### PR TITLE
Fix optional binding error in AppInfoListView.

### DIFF
--- a/Sources/AppInfoList/AppInfoListView.swift
+++ b/Sources/AppInfoList/AppInfoListView.swift
@@ -34,9 +34,7 @@ public struct AppInfoListView: View {
                 if let url = info.privacyPolicyURL {
                     privacyPolicy(url: url)
                 }
-                if let url = licenseFileURL {
-                    license(url: url)
-                }
+                license(url: licenseFileURL)
                 version
             }
         }


### PR DESCRIPTION
Hello Maintainer,

I hope this message finds you well. While I was going through the codebase, I found a place where optional binding is being used even though it's not needed. 

The relevant process will result in an error in the Xcode 14.3.1 development environment.

Allowing the licenseFileURL property to be passed directly, given that it is always non-nil

Best Regards,